### PR TITLE
Bytt mockebibliotek fra Moq til NSubstitute

### DIFF
--- a/Tests/0-starting-point/Tests.0-starting-point.csproj
+++ b/Tests/0-starting-point/Tests.0-starting-point.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" />

--- a/Tests/0-starting-point/Unit/ProductServiceTests.cs
+++ b/Tests/0-starting-point/Unit/ProductServiceTests.cs
@@ -1,4 +1,4 @@
-using Moq;
+using NSubstitute;
 using SalesApi.Domain.DomainPrimitives;
 using SalesApi.Domain.Model;
 using SalesApi.Domain.Services;

--- a/Tests/0-starting-point/Unit/ProductsControllerTests.cs
+++ b/Tests/0-starting-point/Unit/ProductsControllerTests.cs
@@ -1,7 +1,7 @@
 ﻿using AutoMapper;
 using Contracts;
 using Microsoft.AspNetCore.Mvc;
-using Moq;
+using NSubstitute;
 using SalesApi.Controllers;
 using SalesApi.Domain.DomainPrimitives;
 using SalesApi.Domain.Model;
@@ -28,7 +28,7 @@ public class ProductsControllerTests
         Assert.Fail();
     }
 
-    [Xunit.Theory]
+    [Theory]
     [InlineData("")]
     [InlineData("no spaces")]
     [InlineData("thisisanidthatistoolong")]

--- a/Tests/README.md
+++ b/Tests/README.md
@@ -68,6 +68,32 @@ Our first set of unit tests will test the ProductId domain primitive, which is r
 
 Implement the three test methods defined in `ProductIdTests.cs`
 
+<details>
+<summary><b>Hints (Test methods 1 and 2)</b></summary>
+<p>
+
+- The first test method (`Constructor_Should_Reject_InvalidData`) runs once for each line in the file `blns-injection.txt`.
+
+- What do you expect the constructor in the `ProductId`-class to do when it is given an invalid product ID?
+
+- In Xunit, you can verify that a method throws a specific exception using `Assert.Throws<ExceptionType>(() => MethodToTest())`.
+
+</p>
+</details>
+
+<details>
+<summary><b>Hints (Test method 3)</b></summary>
+<p>
+
+- The third test method runs once for each input defined by `InlineData`.
+
+- After creating a new ProductId, what do you expect the value of that productId to be?
+
+- In Xunit, you can verify that two values are equal using `Assert.Equal(actualValue, expectedValue)`.
+
+</p>
+</details>
+
 [__Spoiler (full code)__](./completed/Unit/ProductIdTests.cs)
 
 
@@ -123,6 +149,66 @@ productRepository
 
 Complete the test methods defined in `ProductServiceTests.cs`.
 
+<details>
+<summary><b>Hints (Test method 1)</b></summary>
+<p>
+
+- The first test method should run the `GetWith`-method on an instance of `ProductService`:
+
+- The return value from running this method should be a `(ReadDataResult, Product?)`-tuple.
+
+- The `ReadDataResult` should be `NoAccessToOperation` and the `Product` should be `null`.
+
+- You can verify a value is null with Xunit using `Assert.Null(actualValue)`.
+
+</p>
+</details>
+
+<details>
+<summary><b>Hints (Test method 2)</b></summary>
+<p>
+
+- How do we set up the scenario `IfValidClaimButNotExisting`? (Meaning the user has a valid claim, but the requested product does not exist)
+
+- The mocked `PermissionService` should return true for the property `CanReadProducts`.
+
+- The `ReadDataResult` should be `NotFound` and the `Product` should be `null`.
+
+- You can verify a value is null with Xunit using `Assert.Null(actualValue)`.
+
+</p>
+</details>
+
+<details>
+<summary><b>Hints (Test method 3)</b></summary>
+<p>
+
+- How do we set up the scenario `IfNotValidMarket`? (Meaning the user has a valid claim, but the user has no access to the requested market)
+
+- The mocked `PermissionService` should return true for the property `CanReadProducts`.
+
+- The mocked `PermissionService` should return false for calls to the method `HasPermissionToMarket`.
+
+- The `ReadDataResult` should be `NoAccessToData` and the `Product` should be `null`.
+
+</p>
+</details>
+
+<details>
+<summary><b>Hints (Test method 4)</b></summary>
+<p>
+
+- How do we set up the scenario `IfValidClaim`? (Meaning the user has a valid claim and the user has access to the requested market)
+
+- The mocked `PermissionService` should return true for the property `CanReadProducts`.
+
+- The mocked `PermissionService` should return true for calls to the method `HasPermissionToMarket`.
+
+- The `ReadDataResult` should be `Success` and the `Product` should not be `null`.
+
+</p>
+</details>
+
 [__Spoiler (full code)__](./completed/Unit/ProductServiceTests.cs)
 
 
@@ -130,12 +216,99 @@ Complete the test methods defined in `ProductServiceTests.cs`.
 
 Finally we will test the methods in the ProductController class. Again, since these are unit tests, we will need to mock all dependencies to the ProductController class. In this case we will just need to create a mock that implements the `IProductService` interface, and define some return value for the methods we are using in that interface.
 
-[__Spoiler (full code)__](./completed/Unit/ProductsControllerTests.cs)
+<details>
+<summary><b>Hints (Test method 1)</b></summary>
+<p>
 
+- This test method should call the controller and verify that it returns a 200 OK when the `ProductService` is properly mocked.
+
+- How do we set up the mocked `ProductService` scenario `WhenAuthorized`? (Meaning the `ProductService` should return a valid object when called)
+
+- The mocked `PermissionService` should return a `ReadDataResult.Success` and valid `Product` when called by the controller.
+
+- The result from calling the controller should be an `OkObjectResult`.
+
+- In Xunit, you can verify that a value is of a specific type with `Assert.IsType<ExpectedType>(value)`
+
+</p>
+</details>
+
+<details>
+<summary><b>Hints (Test method 2)</b></summary>
+<p>
+
+- This test method should call the controller and verify the returned object is an instance of `ProductDTO`.
+
+- The scenario in this test method is the same as in the first method.
+
+</p>
+</details>
+
+<details>
+<summary><b>Hints (Test method 3)</b></summary>
+<p>
+
+- This test method should call the controller and verify that it returns a 400 BadRequest when the `ProductService` is properly mocked.
+
+- What do you expect the controller to do when it receives an invalid `ProductId`?
+
+- The result type from calling the controller should be a `BadRequestObjectResult`.
+
+- The response body/value should be null.
+
+</p>
+</details>
+
+<details>
+<summary><b>Hints (Test method 4)</b></summary>
+<p>
+
+- This test method should call the controller and verify that it returns a 404 NotFound when the `ProductService` is properly mocked.
+
+- What should the mocked `ProductService` return when a productId is not found?
+
+- The result type from calling the controller should be a `NotFoundResult`.
+
+- The response body/value should be null.
+
+</p>
+</details>
+
+<details>
+<summary><b>Hints (Test method 5)</b></summary>
+<p>
+
+- This test method should call the controller and verify that it returns a 403 Forbidden when the `ProductService` is properly mocked.
+
+- What should the mocked `ProductService` return when a user does not have right claim for read access?
+
+- The result type from calling the controller should be a `ForbidResult`.
+
+- The response body/value should be null.
+
+</p>
+</details>
+
+<details>
+<summary><b>Hints (Test method 6)</b></summary>
+<p>
+
+- This test method should call the controller and verify that it returns a 404 NotFound when the `ProductService` is properly mocked.
+
+- What should the mocked `ProductService` return when the user does not have access to the requested product?
+
+- The result type from calling the controller should be a `NotFoundResult`.
+
+- The response body/value should be null.
+
+</p>
+</details>
+
+[__Spoiler (full code)__](./completed/Unit/ProductsControllerTests.cs)
 
 # Part 2 - Integration Tests
 
-To check that the inidividual parts of our system is working correctly when interacting with each other, we will create some integration tests in addition to the unit tests. 
+To check that the inidividual parts of our system is working correctly when interacting with each other, we will create some integration tests in addition to the unit tests. Here we will not be mocking dependencies, and instead be testing the system as a whole.
 
 The integration tests are located in `Tests/0-starting-point/System/`.
 
@@ -166,6 +339,43 @@ await AuthorizeHttpClient(ProductScope.Read);
 The `ProductTests` class in `ProductTests.cs` inherits from the `BaseTests` class which lets us easily use the HttpClient and authorize it for the tests that need authorization. 
 
 Write tests for the product API testing the `/api/product/{id}` endpoint to receive proper status codes given the different authorizations.
+
+<details>
+<summary><b>Hints (Test method 1)</b></summary>
+<p>
+
+- This test method should verify that when anonymous users (i.e. unauthorized users) call the API, they should receive a 401 Unauthorized response code.
+
+- To call the API, use the `_client` property from the base class: `await _client.GetAsync("api/product/<productId>")`
+
+- Did you remember to add the client secrets to the `testsettings.json`-file in the `0-starting-point` folder?
+
+</p>
+</details>
+
+<details>
+<summary><b>Hints (Test method 2)</b></summary>
+<p>
+
+- This test method should verify that when authorized users with the wrong scope call the API, they should receive a 403 Forbidden response code.
+
+- To authorize requests sent using `_client.GetAsync`, first do a call `await AuthorizeHttpClient(<scope>)` with the desired scope.
+
+- Running GET requests to fetch products from the API requires
+
+</p>
+</details>
+
+<details>
+<summary><b>Hints (Test method 3)</b></summary>
+<p>
+
+- This test method should verify that when authorized users with correct scope call the API, they should receive a 200 OK response code.
+
+- To authorize requests sent using `_client.GetAsync`, first do a call `await AuthorizeHttpClient(<scope>)` with the desired scope.
+
+</p>
+</details>
 
 [__Spoiler (full code)__](./completed/System/ProductTests.cs)
 

--- a/Tests/completed/Tests.completed.csproj
+++ b/Tests/completed/Tests.completed.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" />

--- a/Tests/completed/Unit/ProductsControllerTests.cs
+++ b/Tests/completed/Unit/ProductsControllerTests.cs
@@ -1,7 +1,7 @@
 ﻿using AutoMapper;
 using Contracts;
 using Microsoft.AspNetCore.Mvc;
-using Moq;
+using NSubstitute;
 using SalesApi.Controllers;
 using SalesApi.Domain.DomainPrimitives;
 using SalesApi.Domain.Model;
@@ -17,18 +17,20 @@ public class ProductsControllerTests
     [Fact]
     public async Task GetById_ShouldReturn200_WhenAuthorized()
     {
-        var productService = Mock.Of<IProductService>();
+        var productService = Substitute.For<IProductService>();
         var productId = new ProductId("no1");
-        Mock.Get(productService)
-            .Setup(service => service.GetWith(It.IsAny<ProductId>()))
-            .ReturnsAsync((
-                ReadDataResult.Success,
-                new Product(
-                    productId,
-                    new ProductName("Product 1"),
-                    new Money(9m, "USD"),
-                    new MarketId("no"))
-            ));
+        productService
+            .GetWith(Arg.Any<ProductId>())
+            .Returns(
+                (
+                    ReadDataResult.Success,
+                    new Product(
+                        productId,
+                        new ProductName("Product 1"),
+                        new Money(9m, "USD"),
+                        new MarketId("no"))
+                )
+            );
         var controller = new ProductsController(productService, _mapper);
 
         var result = await controller.GetById(productId.ToString());
@@ -39,18 +41,20 @@ public class ProductsControllerTests
     [Fact]
     public async Task GetById_ShouldReturnProductDTO_WhenAuthorized()
     {
-        var productService = Mock.Of<IProductService>();
+        var productService = Substitute.For<IProductService>();
         var productId = new ProductId("no1");
-        Mock.Get(productService)
-            .Setup(service => service.GetWith(It.IsAny<ProductId>()))
-            .ReturnsAsync((
-                ReadDataResult.Success,
-                new Product(
-                    productId,
-                    new ProductName("Product 1"),
-                    new Money(9m, "USD"),
-                    new MarketId("no"))
-            ));
+        productService
+            .GetWith(Arg.Any<ProductId>())
+            .Returns(
+                (
+                    ReadDataResult.Success,
+                    new Product(
+                        productId,
+                        new ProductName("Product 1"),
+                        new Money(9m, "USD"),
+                        new MarketId("no"))
+                )
+            );
         var controller = new ProductsController(productService, _mapper);
 
         var result = await controller.GetById(productId.ToString());
@@ -66,10 +70,7 @@ public class ProductsControllerTests
     [InlineData("<script>")]
     public async Task GetById_ShouldReturn400_WhenInvalidId(string invalidId)
     {
-        var productService = Mock.Of<IProductService>();
-        Mock.Get(productService)
-            .Setup(service => service.GetWith(It.IsAny<ProductId>()))
-            .ReturnsAsync((ReadDataResult.NoAccessToData, null));
+        var productService = Substitute.For<IProductService>();
         var controller = new ProductsController(productService, _mapper);
 
         var result = await controller.GetById(invalidId);
@@ -81,10 +82,10 @@ public class ProductsControllerTests
     [Fact]
     public async Task GetById_ShouldReturn404_WhenNotFound()
     {
-        var productService = Mock.Of<IProductService>();
-        Mock.Get(productService)
-            .Setup(service => service.GetWith(It.IsAny<ProductId>()))
-            .ReturnsAsync((ReadDataResult.NotFound, null));
+        var productService = Substitute.For<IProductService>();
+        productService
+            .GetWith(Arg.Any<ProductId>())
+            .Returns((ReadDataResult.NotFound, null));
         var controller = new ProductsController(productService, _mapper);
 
         var result = await controller.GetById("no1");
@@ -96,10 +97,10 @@ public class ProductsControllerTests
     [Fact]
     public async Task GetById_ShouldReturn403_WhenCanNotRead()
     {
-        var productService = Mock.Of<IProductService>();
-        Mock.Get(productService)
-            .Setup(service => service.GetWith(It.IsAny<ProductId>()))
-            .ReturnsAsync((ReadDataResult.NoAccessToOperation, null));
+        var productService = Substitute.For<IProductService>();
+        productService
+            .GetWith(Arg.Any<ProductId>())
+            .Returns((ReadDataResult.NoAccessToOperation, null));
         var controller = new ProductsController(productService, _mapper);
 
         var result = await controller.GetById("no1");
@@ -111,10 +112,10 @@ public class ProductsControllerTests
     [Fact]
     public async Task GetById_ShouldReturn404_WhenNoAccessToData()
     {
-        var productService = Mock.Of<IProductService>();
-        Mock.Get(productService)
-            .Setup(service => service.GetWith(It.IsAny<ProductId>()))
-            .ReturnsAsync((ReadDataResult.NoAccessToData, null));
+        var productService = Substitute.For<IProductService>();
+        productService
+            .GetWith(Arg.Any<ProductId>())
+            .Returns((ReadDataResult.NoAccessToData, null));
         var controller = new ProductsController(productService, _mapper);
 
         var result = await controller.GetById("no1");


### PR DESCRIPTION
## Endringer

- Byttet Moq med NSubstitute
- Oppdatert README for nytt mockebibliotek
- Lagt til hint i README for tester. Dette gir mer veiledning enn tidligere, hvor eneste hint hvis man sto fast var å se på fasit.

## NSubstitute vs. FakeItEasy
Kikket litt på FakeItEasy vs. NSubstitute og synes NSub har litt mer forståelig syntaks. Virket også som at NSubstitute er brukt litt mer enn FakeItEasy, men dette var marginalt. De fleste ser ut til å fortsatt bruke Moq.

#### NSubstitute-syntaks:
```csharp
var permissionService = Substitute.For<IPermissionService>();
permissionService.HasPermissionToMarket(Arg.Is(marketId)).Returns(false);
```

#### FakeItEasy-syntaks:
```csharp
var permissionService2 = A.Fake<IPermissionService>();
A.CallTo(() => permissionService2.HasPermissionToMarket(marketId)).Returns(false);
```


Resolves #9 